### PR TITLE
Change - Showing the readable date instead of epoch date

### DIFF
--- a/src/components/Expense.jsx
+++ b/src/components/Expense.jsx
@@ -73,7 +73,7 @@ const Expense = () => {
   let expenses = data.expenses.rows.map((row) => {
     return {
       id: row.id,
-      data: row.date,
+      data: new Date(Number(row.date)).toISOString().split('T')[0],
       description: row.description,
       amount: row.amount,
       method: row.method.name,


### PR DESCRIPTION
## Summary:
Formats the expense date value into a consistent YYYY-MM-DD string before rendering/mapping.
## Changes:
Updates Expense.jsx to convert row.date using new Date(Number(row.date)).toISOString().split('T')[0].
## Risks:
Potential breaking change: row.date is now assumed to be numeric/convertible via Number(...); invalid values may produce incorrect output or errors during date conversion.