### PR TITLE
Pick value from env rather then the CI/CD script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_ANALYTICS_URL=http://localhost:8501/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -13,16 +13,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      # - name: Set up Node.js
-      #   uses: actions/setup-node@v3
-      #   with:
-      #     node-version: '16'
-
-      # - name: Install Dependencies
-      #   run: npm install
-
-      # - name: Build Project
-      #   run: npm run build
 
       - name: Deploy Via SSH
         uses: appleboy/ssh-action@v1.0.3
@@ -31,15 +21,13 @@ jobs:
           username: ubuntu
           key: ${{ secrets.KEY }}
           debug: true
+          envs: SERVER_IP
           script: |
             cd /home/ubuntu/expense-manager-frontend
-            git checkout -- src/components/Analytics.jsx
-            git restore src/components/Analytics.jsx
             git pull origin main
-            sed -i 's|http://localhost:8501/|http://'${SERVER_IP}':8501/|g' src/components/Analytics.jsx
+
+            cat <<EOF > .env
+            VITE_ANALYTICS_URL=http://${SERVER_IP}:8501/
+            EOF
+
             /home/ubuntu/.nvm/versions/node/v23.2.0/bin/pm2 restart frontend-app
-          # remote-user: ${{ secrets.REMOTE_USER }}
-          # server-ip: ${{ secrets.SERVER_IP }}
-          # remote-path: ${{ secrets.REMOTE_PATH }}
-          # local-path: build/
-          # exclude-list: .gitignore

--- a/src/components/Analytics.jsx
+++ b/src/components/Analytics.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
 const Analytics = () => {
+  const ANALYTICS_URL = import.meta.env.VITE_ANALYTICS_URL ?? "http://localhost:8501/";
   return (
     <div className="flex flex-col items-center justify-center w-full min-h-[200px] mt-10 sm:mt-20">
       <iframe
-        src="http://localhost:8501/"
+        src={ANALYTICS_URL}
         title="Expense Analytics"
         className="w-full h-[600px] border rounded"
         allow="clipboard-write"


### PR DESCRIPTION
## 📝 Summary

Moves the Analytics service URL to environment configuration and updates the deployment workflow to inject the server IP at deploy time.

## 🔧 Changes

* Added `VITE_ANALYTICS_URL` to `.env.example`
* Updated `Analytics.jsx` to read the Analytics iframe URL from environment variables with a localhost fallback
* Simplified deploy workflow to generate a `.env` file using `SERVER_IP` instead of mutating source files
* Removed commented-out build and deploy steps from the workflow

## ⚠️ Breaking Changes

* None

## 🧪 Testing

* Not tested

## 📌 Notes

* Deployment now relies on `SERVER_IP` to populate `VITE_ANALYTICS_URL`
* Local development continues to default to `http://localhost:8501/` if env is not set