### PR TITLE
Pass API url from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ generate_pr_context.sh
 
 # PR diff file
 pr-diff.txt
+
+# Ignore .env file containing sensitive information
+.env

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 
+const apiUrl = import.meta.env.VITE_API_URL;
+
 const Login = () => {
   const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
@@ -13,7 +15,7 @@ const Login = () => {
     e.preventDefault();
     try {
       const data = { phone, password };
-      const res = await axios.post("http://localhost:3030/login", data, {
+      const res = await axios.post(`${apiUrl}/login`, data, {
         headers: { "Content-Type": "application/json" },
       });
       if (res && res.data && res.data.token) {

--- a/src/helpers/ApolloClient.js
+++ b/src/helpers/ApolloClient.js
@@ -1,6 +1,7 @@
 import { ApolloClient, HttpLink, ApolloLink, InMemoryCache, concat  } from '@apollo/client';
+const apiUrl = import.meta.env.VITE_API_URL;
 
-const httpLink = new HttpLink({ uri: 'http://localhost:3030/graph-ql' });
+const httpLink = new HttpLink({ uri: `${apiUrl}/graph-ql` });
 
 const authMiddleware = new ApolloLink((operation, forward) => {
   // Always get the latest token for each request


### PR DESCRIPTION
## 📝 Summary

Update API configuration to use environment variables for the base URL instead of hardcoded localhost endpoints.

## 🔧 Changes

* Added `.env` to `.gitignore` to prevent committing sensitive environment variables.
* Introduced `import.meta.env.VITE_API_URL` in:

  * `Login.jsx` for the `/login` endpoint.
  * `ApolloClient.js` for the `/graph-ql` endpoint.
* Replaced hardcoded `http://localhost:3030` URLs with `${apiUrl}`.

## ⚠️ Breaking Changes

* Application now depends on `VITE_API_URL` being defined in the environment. Missing configuration will break API calls.

## 🧪 Testing

* Not explicitly tested (no tests included in this PR context).

## 📌 Notes

* Ensure a valid `VITE_API_URL` is set in the `.env` file (e.g., `VITE_API_URL=http://localhost:3030`).
* Confirm environment variables are properly configured in all deployment environments.