### PR TITLE
Add and Edit Expense accept category and subcategory id, also expense listing to accept source id for expense edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The frontend is optimized for both **desktop** and **mobile** screens.
 
 - **Expense Management**
   - Add, edit, and delete expenses
+  - Category and subcategory selection (Add and Edit)
+  - Method (In-Cash, Debit Card, Credit Card, UPI, AC to AC) and Source; when method is Credit Card, a “Select Card” dropdown is used
+  - Edit form pre-fills from the listing (including source, method, and card) and stays in sync when switching expenses
   - Mark expenses as repaid / pending
   - Attach metadata like tag, source, method, and card name
 
@@ -40,6 +43,29 @@ The frontend is optimized for both **desktop** and **mobile** screens.
   - Apollo Client for GraphQL queries/mutations
   - Tailwind CSS utility-first styling
   - ESLint for consistent code quality
+
+---
+
+## 📝 Add & Edit Expense Components
+
+### Add Expense (`AddExpense.jsx`)
+
+- **Form fields:** Amount, Description, Category, Subcategory, Method, Source, Date, Tag.
+- **Category & subcategory:** Loaded from `getAllTransactionCategories`; subcategory options depend on the selected category and reset when category changes.
+- **Method:** In-Cash, Debit Card, Credit Card, UPI, AC to AC.
+- **Source:**
+  - When **Credit Card** is selected, the Source field shows a **Select Card** dropdown (from `ccSources`), which sets both card and source.
+  - Otherwise, a bank/source dropdown is shown (KOTAK, ICICI, SBI, HSBC, HDFC, CASH).
+- **Submission:** Uses `createExpense` mutation with `amount`, `description`, `method_id`, `source_id`, `exp_date`, `tag`, optional `card_id`, and optional `sub_category_id`. Form resets after success.
+
+### Edit Expense (`EditExpense.jsx`)
+
+- **Usage:** Opened from the expense listing (e.g. edit icon on a row). Receives `expense`, `onClose`, and `onUpdated` as props. Renders as a modal overlay.
+- **Pre-filled data:** All fields are initialized from the passed `expense` object (amount, description, tag, date, category, subcategory, method, source, card when applicable, is repayed). Values stay in sync when the `expense` prop changes (e.g. opening a different expense).
+- **Source & method:** Resolved from the listing using `source_id` and `method_id`, with fallbacks for `source.id` / `method.id` when the API returns nested objects. Display names (e.g. bank name string) are never used as dropdown values so the correct option is selected.
+- **Credit Card:** When method is Credit Card, the Source field shows the **Select Card** dropdown. The current card is shown when the listing provides `card_id` (and `source_id`) in the expense; the expenses query must include `card_id` in the response for this to work.
+- **Category / subcategory:** Initialized and synced from `expense.category_id` / `expense.subcategory_id` (or nested `category` / `subcategory`). Subcategory list is derived from the selected category with safe handling when `subCategories` is missing.
+- **Submission:** Uses `updateExpense` mutation with `id`, `amount`, `description`, `tag`, `is_repayed`, `date`, `source_id`, `method_id`, and optional `card_id`. Calls `onUpdated()` and `onClose()` on success.
 
 ---
 

--- a/src/components/AddExpense.jsx
+++ b/src/components/AddExpense.jsx
@@ -1,40 +1,10 @@
-import { gql, useMutation, useQuery } from "@apollo/client";
-import { useState } from "react";
-import moment from "moment";
 
-const AddExpense = () => {
-  const [amount, setAmount] = useState(0.0);
-  const [description, setDescription] = useState("");
-  const [method_id, setMethod] = useState(0);
-  const [source_id, setSource] = useState(0);
-  const [exp_date, setDate] = useState(moment(new Date()).format("YYYY-MM-DD"));
-  const [tag, setTag] = useState("");
-  const [card_id, setCardId] = useState(null);
 
-  const GET_CARDS_DATA = gql`
-    query getCCSources {
-      ccSources {
-        id
-        issuing_bank
-        card_name
-        source_id
-        method_id
-      }
-    }
-  `;
+  import { gql, useMutation, useQuery } from "@apollo/client";
+  import { useState } from "react";
+  import moment from "moment";
 
-  const {
-    loading: cardsLoading,
-    error: cardsError,
-    data: cardsData,
-  } = useQuery(GET_CARDS_DATA);
-
-  const handleCardChangeDD = (event) => {
-    const [cardId, sourceId] = event.target.value.split(",");
-    setCardId(cardId);
-    setSource(sourceId);
-  };
-
+  // GraphQL mutation for adding expense
   const ADD_EXPENSE_MUTATION = gql`
     mutation addExpense(
       $amount: Float!
@@ -44,6 +14,7 @@ const AddExpense = () => {
       $exp_date: String!
       $tag: String
       $card_id: Int
+      $sub_category_id: Int
     ) {
       expense: createExpense(
         amount: $amount
@@ -53,6 +24,7 @@ const AddExpense = () => {
         date: $exp_date
         tag: $tag
         card_id: $card_id
+        sub_category_id: $sub_category_id
       ) {
         id
         amount
@@ -68,15 +40,77 @@ const AddExpense = () => {
         date
         tag
         created_by
-        updated_by,
+        updated_by
         card_id
+        sub_category_id
       }
     }
   `;
 
-  // eslint-disable-next-line no-unused-vars
-  const [createExpense, { data, loading, error }] =
-    useMutation(ADD_EXPENSE_MUTATION);
+  // GraphQL query for categories and subcategories
+  const GET_CATEGORIES = gql`
+    query getAllTransactionCategories {
+      getAllTransactionCategories {
+        id
+        name
+        is_active
+        is_deleted
+        created_by
+        updated_by
+        subCategories {
+          id
+          name
+          category_id
+        }
+      }
+    }
+  `;
+
+
+const AddExpense = () => {
+  // Category and Subcategory state
+  const [categoryId, setCategoryId] = useState("");
+  const [subCategoryId, setSubCategoryId] = useState("");
+
+  // Category query
+  const { data: categoriesData, loading: categoriesLoading, error: categoriesError } = useQuery(GET_CATEGORIES);
+
+  // Expense form state
+  const [amount, setAmount] = useState(0.0);
+  const [description, setDescription] = useState("");
+  const [method_id, setMethod] = useState(0);
+  const [source_id, setSource] = useState(0);
+  const [exp_date, setDate] = useState(moment(new Date()).format("YYYY-MM-DD"));
+  const [tag, setTag] = useState("");
+  const [card_id, setCardId] = useState(null);
+
+  // Cards query
+  const GET_CARDS_DATA = gql`
+    query getCCSources {
+      ccSources {
+        id
+        issuing_bank
+        card_name
+        source_id
+        method_id
+      }
+    }
+  `;
+  const {
+    loading: cardsLoading,
+    error: cardsError,
+    data: cardsData,
+  } = useQuery(GET_CARDS_DATA);
+
+  // Mutation
+  const [createExpense, { data, loading, error }] = useMutation(ADD_EXPENSE_MUTATION);
+
+  // Handle card dropdown change (must be after setCardId/setSource are defined)
+  const handleCardChangeDD = (event) => {
+    const [cardId, sourceId] = event.target.value.split(",");
+    setCardId(cardId);
+    setSource(sourceId);
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault(); // Prevent the default form submission
@@ -92,6 +126,7 @@ const AddExpense = () => {
           exp_date,
           tag,
           card_id: parseInt(card_id) || null,
+          sub_category_id: subCategoryId ? parseInt(subCategoryId) : null,
         },
       });
 
@@ -103,6 +138,7 @@ const AddExpense = () => {
       setDate(moment(new Date()).format("YYYY-MM-DD"));
       setTag("");
       setCardId(null);
+      setSubCategoryId("");
     } catch (err) {
       console.error("Error creating user:", err);
     }
@@ -132,6 +168,7 @@ const AddExpense = () => {
               required
             />
           </div>
+
           <div className="mb-4">
             <label
               className="block text-gray-700 text-sm font-bold mb-2"
@@ -148,6 +185,51 @@ const AddExpense = () => {
               onChange={(e) => setDescription(e.target.value)}
               required
             />
+          </div>
+
+          {/* Category Dropdown */}
+          <div className="mb-4">
+            <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="category_id">
+              Category
+            </label>
+            <select
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="category_id"
+              value={categoryId}
+              onChange={e => {
+                setCategoryId(e.target.value);
+                setSubCategoryId(""); // Reset subcategory when category changes
+              }}
+              required
+              disabled={categoriesLoading || !categoriesData}
+            >
+              <option value="">Select Category</option>
+              {categoriesData && categoriesData.getAllTransactionCategories.map(cat => (
+                <option key={cat.id} value={cat.id}>{cat.name}</option>
+              ))}
+            </select>
+          </div>
+          {/* Subcategory Dropdown */}
+          <div className="mb-4">
+            <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="subcategory_id">
+              Subcategory
+            </label>
+            <select
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="subcategory_id"
+              value={subCategoryId}
+              onChange={e => setSubCategoryId(e.target.value)}
+              required
+              disabled={!categoryId || categoriesLoading || !categoriesData}
+            >
+              <option value="">Select Subcategory</option>
+              {categoriesData && categoryId &&
+                categoriesData.getAllTransactionCategories
+                  .find(cat => String(cat.id) === String(categoryId))?.subCategories
+                  .map(sub => (
+                    <option key={sub.id} value={sub.id}>{sub.name}</option>
+                  ))}
+            </select>
           </div>
           {/*
         <div className="mb-4">

--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -1,3 +1,21 @@
+// GraphQL query for categories and subcategories
+const GET_CATEGORIES = gql`
+  query getAllTransactionCategories {
+    getAllTransactionCategories {
+      id
+      name
+      is_active
+      is_deleted
+      created_by
+      updated_by
+      subCategories {
+        id
+        name
+        category_id
+      }
+    }
+  }
+`;
 import { gql, useMutation, useQuery } from "@apollo/client";
 import { useState, useEffect } from "react";
 import moment from "moment";
@@ -53,12 +71,7 @@ const UPDATE_EXPENSE_MUTATION = gql`
 `;
 
 const EditExpense = ({ expense, onClose, onUpdated }) => {
-  const [amount, setAmount] = useState(expense.amount);
-  const [description, setDescription] = useState(expense.description);
-  const [tag, setTag] = useState(expense.tag);
-  const [isRepayed, setIsRepayed] = useState(expense.is_repayed === 1 || expense.is_repayed === "Yes");
-
-  // Helper to extract id from possible nested object or direct value
+  // Helper to extract id from possible nested object or direct value (used for initial state)
   function getId(val) {
     if (!val) return "";
     if (typeof val === "string" || typeof val === "number") return String(val);
@@ -67,8 +80,29 @@ const EditExpense = ({ expense, onClose, onUpdated }) => {
     return "";
   }
 
-  const [method_id, setMethod] = useState(getId(expense.method_id || expense.method));
-  const [source_id, setSource] = useState(getId(expense.source_id || expense.source));
+  // Category and Subcategory state — initialize from expense when present
+  const [categoryId, setCategoryId] = useState(() => getId(expense.category_id || expense.category));
+  const [subCategoryId, setSubCategoryId] = useState(() => getId(expense.subcategory_id || expense.subcategory));
+
+  // Category query
+  const { data: categoriesData, loading: categoriesLoading, error: categoriesError } = useQuery(GET_CATEGORIES);
+  const [amount, setAmount] = useState(expense.amount);
+  const [description, setDescription] = useState(expense.description);
+  const [tag, setTag] = useState(expense.tag);
+  const [isRepayed, setIsRepayed] = useState(expense.is_repayed === 1 || expense.is_repayed === "Yes");
+
+  // Resolve source_id from expense: use only numeric id, never the display name (expense.source string)
+  const getSourceIdFromExpense = (exp) => {
+    const raw = exp.source_id ?? (exp.source && typeof exp.source === 'object' && exp.source.id != null ? exp.source.id : undefined);
+    return raw != null ? String(raw) : '';
+  };
+  const getMethodIdFromExpense = (exp) => {
+    const raw = exp.method_id ?? (exp.method && typeof exp.method === 'object' && exp.method.id != null ? exp.method.id : undefined);
+    return raw != null ? String(raw) : '';
+  };
+
+  const [method_id, setMethod] = useState(() => getMethodIdFromExpense(expense));
+  const [source_id, setSource] = useState(() => getSourceIdFromExpense(expense));
   const [card_id, setCardId] = useState(expense.card_id || null);
   // Always use YYYY-MM-DD for input type="date". If missing, use today's date.
   function getValidDate(val) {
@@ -94,6 +128,19 @@ const EditExpense = ({ expense, onClose, onUpdated }) => {
   useEffect(() => {
     setDate(getValidDate(expense.data));
   }, [expense.data]);
+
+  // Sync category/subcategory when expense prop changes (e.g. editing a different expense)
+  useEffect(() => {
+    setCategoryId(getId(expense.category_id || expense.category));
+    setSubCategoryId(getId(expense.subcategory_id || expense.subcategory));
+  }, [expense.id, expense.category_id, expense.category, expense.subcategory_id, expense.subcategory]);
+
+  // Sync source_id, method_id, card_id when expense prop changes so edit form gets values from listing
+  useEffect(() => {
+    setSource(getSourceIdFromExpense(expense));
+    setMethod(getMethodIdFromExpense(expense));
+    setCardId(expense.card_id ?? null);
+  }, [expense.id, expense.source_id, expense.source, expense.method_id, expense.method, expense.card_id]);
 
   const {
     loading: cardsLoading,
@@ -163,6 +210,51 @@ const EditExpense = ({ expense, onClose, onUpdated }) => {
           <div className="mb-4">
             <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="description">Description</label>
             <input className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" id="description" type="text" value={description} onChange={e => setDescription(e.target.value)} required />
+          </div>
+
+          {/* Category Dropdown */}
+          <div className="mb-4">
+            <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="category_id">
+              Category
+            </label>
+            <select
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="category_id"
+              value={categoryId}
+              onChange={e => {
+                setCategoryId(e.target.value);
+                setSubCategoryId(""); // Reset subcategory when category changes
+              }}
+              required
+              disabled={categoriesLoading || !categoriesData}
+            >
+              <option value="">Select Category</option>
+              {categoriesData && categoriesData.getAllTransactionCategories.map(cat => (
+                <option key={cat.id} value={cat.id}>{cat.name}</option>
+              ))}
+            </select>
+          </div>
+          {/* Subcategory Dropdown */}
+          <div className="mb-4">
+            <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="subcategory_id">
+              Subcategory
+            </label>
+            <select
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="subcategory_id"
+              value={subCategoryId}
+              onChange={e => setSubCategoryId(e.target.value)}
+              required
+              disabled={!categoryId || categoriesLoading || !categoriesData}
+            >
+              <option value="">Select Subcategory</option>
+              {categoriesData && categoryId &&
+                (categoriesData.getAllTransactionCategories
+                  .find(cat => String(cat.id) === String(categoryId))?.subCategories ?? [])
+                  .map(sub => (
+                    <option key={sub.id} value={sub.id}>{sub.name}</option>
+                  ))}
+            </select>
           </div>
           <div className="mb-4">
             <label className="block text-gray-700 text-sm font-bold mb-2" htmlFor="tag">Tag</label>

--- a/src/components/Expense.jsx
+++ b/src/components/Expense.jsx
@@ -77,9 +77,11 @@ const GET_EXPENSES = gql`
         source_id
         method_id
         method {
+          id
           name
         }
         source {
+          id
           name
         }
         user {
@@ -88,6 +90,7 @@ const GET_EXPENSES = gql`
           username
         }
         is_repayed
+        card_id
         card_name
         tag
       }
@@ -163,18 +166,22 @@ const Expense = () => {
     );
   }
   let expenses = data.expenses.rows.map((row) => {
+    const sourceId = row.source_id ?? row.sourceId ?? row.source?.id;
+    const methodId = row.method_id ?? row.methodId ?? row.method?.id;
+    const cardId = row.card_id ?? row.cardId;
     return {
       id: row.id,
       data: new Date(Number(row.date)).toISOString().split("T")[0],
       description: row.description,
       amount: row.amount,
-      method: row.method.name,
-      source: row.source.name,
+      method: row.method?.name,
+      source: row.source?.name,
       first_name: row.user.first_name,
       is_repayed: row.is_repayed ? "Yes" : "No",
       tag: row.tag ? row.tag : "N/A",
-      source_id: row.source_id,
-      method_id: row.method_id,
+      source_id: sourceId != null ? String(sourceId) : undefined,
+      method_id: methodId != null ? String(methodId) : undefined,
+      card_id: cardId != null ? cardId : null,
       card_name: row.card_name ? row.card_name : "N/A",
     };
   });


### PR DESCRIPTION
## 📝 Summary

Enhance Add and Edit Expense flows to support category/subcategory selection, improve source/method handling, and persist related IDs correctly.

## 🔧 Changes

* **README.md**

  * Documented Add/Edit Expense behavior, including category, subcategory, method, source, and credit card handling.
* **AddExpense.jsx**

  * Added `getAllTransactionCategories` query.
  * Implemented Category and Subcategory dropdowns (subcategory depends on selected category).
  * Included `sub_category_id` in `createExpense` mutation.
  * Reset subcategory when category changes and after successful submission.
* **EditExpense.jsx**

  * Added categories query and dropdowns for Category/Subcategory.
  * Initialized and synced category/subcategory from `expense` prop.
  * Improved syncing of `source_id`, `method_id`, and `card_id` when editing different expenses.
  * Safely handled nested `source`/`method` objects.
* **Expense.jsx**

  * Normalized `source_id`, `method_id`, and `card_id` extraction.
  * Used optional chaining for safer property access.

## ⚠️ Breaking Changes

* None explicitly introduced in this diff.

## 🧪 Testing

* Not explicitly tested (no tests included in this PR context).

## 📌 Notes

* Requires `getAllTransactionCategories` query to be available in the API.
* Edit flow depends on `card_id` being included in the expenses query response.