### PR TITLE
Edit Expense to accept sub-category capturing

### DIFF
--- a/src/components/EditExpense.jsx
+++ b/src/components/EditExpense.jsx
@@ -43,6 +43,7 @@ const UPDATE_EXPENSE_MUTATION = gql`
     $source_id: Int
     $method_id: Int
     $card_id: Int
+    $sub_category_id: Int
   ) {
     updateExpense(
       id: $id
@@ -54,6 +55,7 @@ const UPDATE_EXPENSE_MUTATION = gql`
       source_id: $source_id
       method_id: $method_id
       card_id: $card_id
+      sub_category_id: $sub_category_id
     ) {
       id
       amount
@@ -66,6 +68,7 @@ const UPDATE_EXPENSE_MUTATION = gql`
       created_by
       updated_by
       card_id
+      sub_category_id
     }
   }
 `;
@@ -192,6 +195,7 @@ const EditExpense = ({ expense, onClose, onUpdated }) => {
         source_id: parseInt(source_id),
         method_id: parseInt(method_id),
         card_id: parseInt(card_id) || null,
+        sub_category_id: subCategoryId ? parseInt(subCategoryId) : null,
       },
     });
     if (onUpdated) onUpdated();


### PR DESCRIPTION
## 📝 Summary

Updates the expense edit functionality to support `sub_category_id` in the GraphQL mutation and payload.

## 🔧 Changes

* Added `$sub_category_id: Int` variable to the GraphQL mutation.
* Included `sub_category_id` in the mutation input payload.
* Added `sub_category_id` to the returned mutation fields.
* Passed `sub_category_id` from component state, converting `subCategoryId` to `Int` or `null`.

## ⚠️ Breaking Changes

* None

## 🧪 Testing

* Done Locally

## 📌 Notes

* `sub_category_id` is conditionally set using `parseInt(subCategoryId)` when a value exists, otherwise `null`.
